### PR TITLE
Add color history and RGB copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ python app.py
 ```
 
 Click **Pick color** to choose a color. The HEX, RGB and HSV values are displayed and the HEX code is copied to the clipboard.
+Each picked color is stored in a history list and can be revisited later.
+Use the **Copy RGB** button to copy the RGB value to the clipboard.
 
 ## Tests
 

--- a/app.py
+++ b/app.py
@@ -9,6 +9,15 @@ def rgb_to_hsv(r: int, g: int, b: int):
     """
     return colorsys.rgb_to_hsv(r / 255.0, g / 255.0, b / 255.0)
 
+
+def add_to_history(history, color, limit=10):
+    """Add a color to the beginning of the history list.
+
+    Ensures the history does not grow beyond ``limit`` items.
+    Returns the new history list.
+    """
+    return [color] + history[: limit - 1]
+
 def main():
     root = tk.Tk()
     root.title("Color Picker")
@@ -17,7 +26,18 @@ def main():
     rgb_var = tk.StringVar()
     hsv_var = tk.StringVar()
 
+    color_history = []
+    history_listbox = tk.Listbox(root, height=10)
+
+    def copy_rgb():
+        text = rgb_var.get()
+        if text:
+            root.clipboard_clear()
+            root.clipboard_append(text)
+            root.update()
+
     def pick_color():
+        nonlocal color_history
         result = colorchooser.askcolor()
         if not result or not result[0]:
             return
@@ -33,6 +53,11 @@ def main():
         root.clipboard_append(hex_color)
         root.update()
 
+        color_history = add_to_history(color_history, hex_color)
+        history_listbox.delete(0, tk.END)
+        for c in color_history:
+            history_listbox.insert(tk.END, c)
+
     tk.Button(root, text="Pick color", command=pick_color).pack(pady=10)
 
     tk.Label(root, text="HEX:").pack()
@@ -40,9 +65,13 @@ def main():
 
     tk.Label(root, text="RGB:").pack()
     tk.Label(root, textvariable=rgb_var).pack()
+    tk.Button(root, text="Copy RGB", command=copy_rgb).pack(pady=5)
 
     tk.Label(root, text="HSV:").pack()
     tk.Label(root, textvariable=hsv_var).pack()
+
+    tk.Label(root, text="History:").pack()
+    history_listbox.pack()
 
     root.mainloop()
 

--- a/test_color_utils.py
+++ b/test_color_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from app import rgb_to_hsv
+from app import rgb_to_hsv, add_to_history
 
 class TestColorUtils(unittest.TestCase):
     def test_rgb_to_hsv_red(self):
@@ -7,6 +7,14 @@ class TestColorUtils(unittest.TestCase):
         self.assertAlmostEqual(h, 0.0)
         self.assertAlmostEqual(s, 1.0)
         self.assertAlmostEqual(v, 1.0)
+
+    def test_add_to_history_limit_and_order(self):
+        history = []
+        colors = [f"#{i}{i}{i}{i}{i}{i}" for i in "012345"]
+        for color in colors:
+            history = add_to_history(history, color, limit=5)
+        expected = ['#555555', '#444444', '#333333', '#222222', '#111111']
+        self.assertEqual(history, expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add color history list
- copy RGB button
- unit tests for history

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68b2375922cc832da90def1991f955a2