### PR TITLE
Add PyInstaller packaging instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!color_picker.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -21,3 +21,25 @@ Use the **Copy RGB** button to copy the RGB value to the clipboard.
 ```bash
 python -m unittest
 ```
+
+## Packaging
+
+Use [PyInstaller](https://pyinstaller.org/) to build standalone executables for
+Windows and macOS.
+
+### Windows
+
+```bash
+pip install pyinstaller
+pyinstaller color_picker.spec
+```
+
+### macOS
+
+```bash
+pip install pyinstaller
+pyinstaller color_picker.spec
+```
+
+The binaries will be available in the `dist/` directory once the build
+completes.

--- a/color_picker.spec
+++ b/color_picker.spec
@@ -1,0 +1,43 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(
+    ['app.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='color-picker',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='color-picker'
+)


### PR DESCRIPTION
## Summary
- add PyInstaller spec file for creating standalone builds
- document Windows and macOS packaging steps
- track the spec file in the repository

## Testing
- `python -m unittest`
- `pip install pyinstaller` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b23c9b7104832da26a7233ca8da9e2